### PR TITLE
Refactor/creating llm package

### DIFF
--- a/contextual_data_augmentation.go
+++ b/contextual_data_augmentation.go
@@ -58,7 +58,6 @@ type LLMOutput struct {
 
 func parseLLMOutput(modelOutput string) (*LLMOutput, error) {
 	llmOutput := &LLMOutput{}
-	fmt.Println(modelOutput)
 
 	// Regular expressions for parsing
 	choiceRegex := regexp.MustCompile(`([A-D])\. (.*)`)

--- a/contextual_data_augmentation.go
+++ b/contextual_data_augmentation.go
@@ -13,22 +13,21 @@ import (
 
 // ContextualDataAugmentation is a PTransform that uses an LLM for Contextual Data Augmentation
 type ContextualDataAugmentation struct {
-	Model llm.LanguageModel
+	model llm.LanguageModel
 	once  sync.Once
 }
 
 func (cda *ContextualDataAugmentation) ProcessElement(ctx context.Context, question *Question) (*MultipleChoiceQuestion, error) {
 	// Lazy initialization
 	cda.once.Do(func() {
-		cda.Model = llm.NewAnthropicLLM("")
-		cda.Model.SetupClient()
+		cda.model = llm.NewAnthropicLLM("")
 	})
 
 	// Building the prompt
 	prompt := fmt.Sprintf(`Analyze the following question and provide: 1. Four choices that could be used as answers. 2. Indicate which choice is correct. 3. The choices makes the question easy to answer. Question: %s , the question belongs to the following exam's sections: %s and has ben tag with the following labels: %s. Please keep your output scoped to the Google Cloud Platform and respond in the following format: Choices: A. [choice1] B. [choice2] C. [choice3] D. [choice4]. Answer: [A/B/C/D]. Explanation: [explanation]. Please avoid at all cost any comments or explanation!`, question.Text, strings.Join(question.Sections, ","), strings.Join(question.Labels, ","))
 
 	// Using chat completion
-	llmOutput, err := cda.Model.GenerateText(ctx, prompt)
+	llmOutput, err := cda.model.GenerateText(ctx, prompt)
 	if err != nil {
 		return nil, fmt.Errorf("error in generating text from LLM: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/gage-technologies/mistral-go v1.1.0
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzP
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsouza/fake-gcs-server v1.47.7 h1:56/U4rKY081TaNbq0gHWi7/71UxC2KROqcnrD9BRJhs=
 github.com/fsouza/fake-gcs-server v1.47.7/go.mod h1:4vPUynN8/zZlxk5Jpy6LvvTTxItdTAObK4DYnp89Jys=
+github.com/gage-technologies/mistral-go v1.1.0 h1:POv1wM9jA/9OBXGV2YdPi9Y/h09+MjCbUF+9hRYlVUI=
+github.com/gage-technologies/mistral-go v1.1.0/go.mod h1:tF++Xt7U975GcLlzhrjSQb8l/x+PrriO9QEdsgm9l28=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
 github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/llm/antropic_client.go
+++ b/llm/antropic_client.go
@@ -1,0 +1,50 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/liushuangls/go-anthropic/v2"
+)
+
+type AnthropicLLM struct {
+	ModelName string
+	client    *anthropic.Client
+}
+
+func NewAnthropicLLM(modelName string) LanguageModel {
+	if modelName == "" {
+		modelName = anthropic.ModelClaudeInstant1Dot2
+	}
+	return &AnthropicLLM{
+		ModelName: modelName,
+	}
+}
+
+func (a *AnthropicLLM) GenerateText(ctx context.Context, prompt string) (string, error) {
+	// Using chat completion
+	resp, err := a.client.CreateMessages(ctx, anthropic.MessagesRequest{
+		Model: a.ModelName,
+		Messages: []anthropic.Message{
+			anthropic.NewUserTextMessage(prompt),
+		},
+		MaxTokens: 1000,
+	})
+	if err != nil {
+		var e *anthropic.APIError
+		if errors.As(err, &e) {
+			return "", fmt.Errorf("anthropic API error, type: %s, message: %s", e.Type, e.Message)
+		}
+		return "", fmt.Errorf("anthropic API error: %w", err)
+	}
+
+	// return generated text
+	return *resp.Content[0].Text, nil
+}
+
+func (a *AnthropicLLM) SetupClient() {
+	CLAUDE_API_KEY := os.Getenv("CLAUDE_API_KEY")
+	a.client = anthropic.NewClient(CLAUDE_API_KEY)
+}

--- a/llm/antropic_client.go
+++ b/llm/antropic_client.go
@@ -18,8 +18,11 @@ func NewAnthropicLLM(modelName string) LanguageModel {
 	if modelName == "" {
 		modelName = anthropic.ModelClaudeInstant1Dot2
 	}
+
+	CLAUDE_API_KEY := os.Getenv("CLAUDE_API_KEY")
 	return &AnthropicLLM{
 		ModelName: modelName,
+		client:    anthropic.NewClient(CLAUDE_API_KEY),
 	}
 }
 
@@ -42,9 +45,4 @@ func (a *AnthropicLLM) GenerateText(ctx context.Context, prompt string) (string,
 
 	// return generated text
 	return *resp.Content[0].Text, nil
-}
-
-func (a *AnthropicLLM) SetupClient() {
-	CLAUDE_API_KEY := os.Getenv("CLAUDE_API_KEY")
-	a.client = anthropic.NewClient(CLAUDE_API_KEY)
 }

--- a/llm/main.go
+++ b/llm/main.go
@@ -1,0 +1,10 @@
+package llm
+
+import (
+	"context"
+)
+
+type LanguageModel interface {
+	GenerateText(context.Context, string) (string, error)
+	SetupClient()
+}

--- a/llm/main.go
+++ b/llm/main.go
@@ -6,5 +6,4 @@ import (
 
 type LanguageModel interface {
 	GenerateText(context.Context, string) (string, error)
-	SetupClient()
 }

--- a/llm/mistral_client.go
+++ b/llm/mistral_client.go
@@ -1,0 +1,39 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gage-technologies/mistral-go"
+)
+
+type mistralLLM struct {
+	ModelName string
+	client    *mistral.MistralClient
+}
+
+func NewMistralLLM(modelName string) LanguageModel {
+	if modelName == "" {
+		modelName = "mistral-small-latest"
+	}
+
+	return &mistralLLM{
+		ModelName: modelName,
+		client:    mistral.NewMistralClientDefault(""),
+	}
+}
+
+func (m *mistralLLM) GenerateText(ctx context.Context, prompt string) (string, error) {
+	// Using chat completion
+	resp, err := m.client.Chat(m.ModelName, []mistral.ChatMessage{{Content: prompt, Role: mistral.RoleUser}}, &mistral.ChatRequestParams{
+		Temperature: 0.7,
+		MaxTokens:   512,
+		TopP:        1,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error getting chat completion: %w", err)
+	}
+
+	// return generated text
+	return resp.Choices[0].Message.Content, nil
+}

--- a/llm_client.go
+++ b/llm_client.go
@@ -2,69 +2,53 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
-	"github.com/liushuangls/go-anthropic/v2"
+	"github.com/luillyfe/data-pipelines/llm"
 )
 
-// LLMClient is a PTransform that enriches questions with multiple choice options using an LLM
-type LLMClient struct {
-	ModelName string
-	client    *anthropic.Client
-	once      sync.Once
+// LLMProvider is a PTransform that uses an LLM for Contextual Data Augmentation
+type LLMProvider struct {
+	Model llm.LanguageModel
+	once  sync.Once
 }
 
-func (llm *LLMClient) ProcessElement(ctx context.Context, question *Question) (*MultipleChoiceQuestion, error) {
+func (provider *LLMProvider) ProcessElement(ctx context.Context, question *Question) (*MultipleChoiceQuestion, error) {
 	// Lazy initialization
-	llm.once.Do(func() {
-		llm.setupClient()
+	provider.once.Do(func() {
+		provider.Model = llm.NewAnthropicLLM("")
+		provider.Model.SetupClient()
 	})
 
+	// Building the prompt
 	prompt := fmt.Sprintf(`Analyze the following question and provide: 1. Four choices that could be used as answers. 2. Indicate which choice is correct. 3. The choices makes the question easy to answer. Question: %s , the question belongs to the following exam's sections: %s and has ben tag with the following labels: %s. Please keep your output scoped to the Google Cloud Platform and respond in the following format: Choices: A. [choice1] B. [choice2] C. [choice3] D. [choice4]. Answer: [A/B/C/D]. Explanation: [explanation]. Please avoid at all cost any comments or explanation!`, question.Text, strings.Join(question.Sections, ","), strings.Join(question.Labels, ","))
 
-	// Using Chat completion
-	resp, err := llm.client.CreateMessages(context.Background(), anthropic.MessagesRequest{
-		Model: anthropic.ModelClaudeInstant1Dot2,
-		Messages: []anthropic.Message{
-			anthropic.NewUserTextMessage(prompt),
-		},
-		MaxTokens: 1000,
-	})
+	// Using chat completion
+	llmOutput, err := provider.Model.GenerateText(ctx, prompt)
 	if err != nil {
-		var e *anthropic.APIError
-		if errors.As(err, &e) {
-			fmt.Printf("Messages error, type: %s, message: %s", e.Type, e.Message)
-		} else {
-			fmt.Printf("Messages error: %v\n", err)
-		}
+		return nil, fmt.Errorf("error in generating text from LLM: %w", err)
 	}
 
 	// Parse LLM Output.
-	llmOutput, err := parseLLMOutput(*resp.Content[0].Text)
+	ParsedLLMOutput, err := parseLLMOutput(llmOutput)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing LLM response: %w", err)
 	}
 
 	// Parse to MultipleChoiceQuestion
-	mQuestion := parseToMultipleQuestion(question, llmOutput.Choices, llmOutput.Answer, llmOutput.Explanation)
+	mQuestion := parseToMultipleQuestion(question, ParsedLLMOutput.Choices, ParsedLLMOutput.Answer, ParsedLLMOutput.Explanation)
 
+	// Return
 	return mQuestion, nil
 }
 
 func init() {
 	// type arguments [context.Context, *Question, *MultipleChoiceQuestion, error]
-	register.DoFn2x2(&LLMClient{})
-}
-
-func (llm *LLMClient) setupClient() {
-	CLAUDE_API_KEY := os.Getenv("CLAUDE_API_KEY")
-	llm.client = anthropic.NewClient(CLAUDE_API_KEY)
+	register.DoFn2x2(&LLMProvider{})
 }
 
 type LLMOutput struct {

--- a/main.go
+++ b/main.go
@@ -42,9 +42,9 @@ func main() {
 	// Filter out nil questions
 	validQuestions = filter.Exclude(s, validQuestions, isNilQuestion)
 
-	// Contextual Data Augmentation (From free-response to Multiple-Choice Questions) using an LLM
-	llmProvider := &LLMProvider{}
-	mQuestions := beam.ParDo(s, llmProvider, validQuestions)
+	// Contextual Data Augmentation (From free-response to Multiple-Choice Questions)
+	contextualDataAugmentation := &ContextualDataAugmentation{}
+	mQuestions := beam.ParDo(s, contextualDataAugmentation, validQuestions)
 
 	// Initialize the firestore writer
 	firestoreWriter := &FirestoreWriter{

--- a/main.go
+++ b/main.go
@@ -42,9 +42,9 @@ func main() {
 	// Filter out nil questions
 	validQuestions = filter.Exclude(s, validQuestions, isNilQuestion)
 
-	// Contextual Data Augmentation With Claude (From free-response to Multiple-Choice Questions)
-	llmClient := &LLMClient{}
-	mQuestions := beam.ParDo(s, llmClient, validQuestions)
+	// Contextual Data Augmentation (From free-response to Multiple-Choice Questions) using an LLM
+	llmProvider := &LLMProvider{}
+	mQuestions := beam.ParDo(s, llmProvider, validQuestions)
 
 	// Initialize the firestore writer
 	firestoreWriter := &FirestoreWriter{


### PR DESCRIPTION
### LLM Package Refactoring: Modular and Extensible Language Model Integration

**Overview**
This PR introduces a significant refactoring of our Language Model integration, creating a modular and extensible package for easely swapping between different LLM providers.

**Key Changes** 
1. Introduced a `LanguageModel` interface in `llm/main.go` to standardize LLM interactions.
2. Implemented Anthropic support in `anthropic_client.go`
3. Added Mistral support in `mistral_client.go`
4. Abstracted common LLM functionality to allow for easy addition of new providers.

**Detailed Changes**
**1. LanguageModel Interface**

- Created a new interface in `llm/main.go` that defines a common `GenerateText` method for all LLM implementations.

**2. Anthropic Implementation**

- Refactored existing anthropic integration into `AnthropicLLM` struct in `anthropic_client.go`
- Implemented the `LanguageModel` interface for Anthropic.
- Adding configurability for model selection.

**3. Mistral Implementation**

- Added new `MistralLLM` struct in `mistral_client.go` to support Mistral's LLMs.
- Implemented the `LanguageModel` interface for Mistral.
- Included model selection and default configurations.

**Benefits**

- **Modularity**: Each LLM provider is encapsulated in its own struct and file.
- **Flexibility**: Easily swap between different LLM provider or add new ones.
- **Consistency**: Standardized interface for all LLM interactions.
- **Extensibility**: Simple process to add new functionality across LLMs.

```go
var llm LanguageModel
llm = NewAnthropicLLM("") // or NewMistralLLM("")
response, err := llm.GenerateText(context.Background(), "Your prompt here")
```